### PR TITLE
Add initial Chart files and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# wg-access-server Helm Chart Repository
+
+This repository contains the Helm Chart files for the [wg-access-server](https://github.com/freifunkMUC/wg-access-server) project.

--- a/charts/wg-access-server/.helmignore
+++ b/charts/wg-access-server/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/wg-access-server/Chart.yaml
+++ b/charts/wg-access-server/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+appVersion: v0.6.0
+description: A Wireguard VPN Access Server
+name: wg-access-server
+version: v0.6.0

--- a/charts/wg-access-server/README.md
+++ b/charts/wg-access-server/README.md
@@ -1,0 +1,105 @@
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install my-release --repo https://freie-netze.org/wg-access-server wg-access-server
+```
+
+The command deploys wg-access-server on the Kubernetes cluster in the default configuration. The configuration section lists the parameters that can be configured during installation.
+
+A wireguard private key needs to be set in order for the pod to start successfully. Use `wg genkey` and append `--set wireguard.config.privateKey="<wg-private-key>"` to the command above.
+
+Per default persistence is disabled and devices will not persist. To enable persistence, set `persistence.enabled`.
+
+Because IPv6 on Kubernetes is disabled by default in most clusters and can't be enabled on a per-pod basis, the default `values.yaml` disables it for the VPN as well. If you have a cluster with working IPv6, set `config: {}` in your `values.yaml` or specify a custom VPN-internal prefix under `config.vpn.cidrv6`.
+
+If no admin password is set, the Chart generates a random one. You can retrieve it using `kubectl get secret ...` as prompted by helm after installing the Chart.
+
+## Uninstalling the Chart
+
+To uninstall/delete the my-release deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Example values.yaml
+
+```yaml
+config:
+  externalHost: "<loadbalancer-ip>"
+
+# wg access server is an http server without TLS. Exposing it via a loadbalancer is NOT secure!
+# Uncomment the following section only if you are running on private network or simple testing.
+# A much better option would be TLS terminating ingress controller or reverse-proxy.
+# web:
+#   service:
+#     type: "LoadBalancer"
+#     loadBalancerIP: "<loadbalancer-ip>"
+
+wireguard:
+  config:
+    privateKey: "<wireguard-private-key>"
+  service:
+    type: "LoadBalancer"
+    loadBalancerIP: "<loadbalancer-ip>"
+
+persistence:
+  enabled: true
+
+ingress:
+  enabled: true
+  hosts: ["vpn.example.com"]
+  tls:
+    - hosts: ["vpn.example.com"]
+      secretName: "tls-wg-access-server"
+```
+
+
+
+## All Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| config | object | `{}` | inline wg-access-server config (config.yaml) |
+| web.config.adminUsername | string | `"admin"` |  |
+| web.config.adminPassword | string | `""` | If omitted a random password will be generated and stored in the secret |
+| web.service.annotations | object | `{}` |  |
+| web.service.externalTrafficPolicy | string | `""` |  |
+| web.service.type | string | `"ClusterIP"` |  |
+| web.service.loadBalancerIP | string | `""` |  |
+| wireguard.config.privateKey | string | `""` | REQUIRED - A wireguard private key. You can generate one using `$ wg genkey` |
+| wireguard.service.annotations | object | `{}` |  |
+| wireguard.service.type | string | `"ClusterIP"` |  |
+| wireguard.service.sessionAffinity | string | `"ClientIP"` |  |
+| wireguard.service.externalTrafficPolicy | string | `""` |  |
+| wireguard.service.ipFamilyPolicy | string | `"SingleStack"` |  |
+| wireguard.service.loadBalancerIP | string | `""` |  |
+| wireguard.service.port | int | `51820` |  |
+| wireguard.service.nodePort | int | `""` | Use available port from range 30000-32768 |
+| persistence.enabled | bool | `false` |  |
+| persistence.existingClaim | string | `""` | Use existing PVC claim for persistence instead |
+| persistence.annotations | object | `{}` |  |
+| persistence.accessModes[0] | string | `"ReadWriteOnce"` |  |
+| persistence.storageClass | string | `""` |  |
+| persistence.size | string | `"100Mi"` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.ingressClassName | string | `""` |  |
+| ingress.hosts | list | `[]` |  |
+| ingress.tls | list | `[]` |  |
+| nameOverride | string | `""` |  |
+| fullnameOverride | string | `""` |  |
+| imagePullSecrets | list | `[]` |  |
+| image.repository | string | `"ghcr.io/freifunkmuc/wg-access-server"` |  |
+| image.tag | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| replicas | int | `1` |  |
+| strategy.type | string | `""` | `Recreate` if `persistence.enabled` true or `RollingUpdate` if false |
+| resources | object | `{}` | pod cpu/memory resource requests and limits |
+| nodeSelector | object | `{}` |  |
+| tolerations | list | `[]` |  |
+| affinity | object | `{}` |  |

--- a/charts/wg-access-server/templates/NOTES.txt
+++ b/charts/wg-access-server/templates/NOTES.txt
@@ -1,0 +1,16 @@
+
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+{{- $fullName := include "wg-access-server.fullname" . }}
+{{ if .Values.ingress.enabled }}
+You can find the web interface at:
+    {{- range .Values.ingress.hosts }}
+    - {{ . }}
+    {{- end }}
+{{- end }}
+{{ if empty .Values.web.config.adminPassword }}
+You can display the auto-generated admin password by running:
+  $ kubectl get secret --namespace {{ .Release.Namespace }} {{ $fullName }} -o jsonpath="{.data.adminPassword}" | base64 --decode
+{{- end }}

--- a/charts/wg-access-server/templates/_helpers.tpl
+++ b/charts/wg-access-server/templates/_helpers.tpl
@@ -1,0 +1,80 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "wg-access-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "wg-access-server.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "wg-access-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "wg-access-server.labels" -}}
+helm.sh/chart: {{ include "wg-access-server.chart" . }}
+{{ include "wg-access-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "wg-access-server.selectorLabels" -}}
+app: {{ include "wg-access-server.name" . }}
+app.kubernetes.io/name: {{ include "wg-access-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "wg-access-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "wg-access-server.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a randomly generated admin password if none is supplied
+*/}}
+{{- define "wg-access-server.adminPassword" -}}
+{{- if .Values.web.config.adminPassword -}}
+    {{ .Values.web.config.adminPassword }}
+{{- else -}}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace (include "wg-access-server.fullname" .)) -}}
+{{- if $secret -}}
+    {{-  $secret.data.adminPassword | b64dec -}}
+{{- else -}}
+    {{- randAlphaNum 20 -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/wg-access-server/templates/configmap.yaml
+++ b/charts/wg-access-server/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "wg-access-server.fullname" . }}
+  labels:
+    {{- include "wg-access-server.labels" . | nindent 4 }}
+data:
+  config.yaml: |-
+{{- if .Values.config }}
+{{ toYaml .Values.config | indent 4 }}
+{{- end }}

--- a/charts/wg-access-server/templates/deployment.yaml
+++ b/charts/wg-access-server/templates/deployment.yaml
@@ -1,0 +1,108 @@
+{{- $fullName := include "wg-access-server.fullname" . -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "wg-access-server.fullname" . }}
+  labels:
+    {{- include "wg-access-server.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  strategy:
+    {{- if .Values.persistence.enabled  }}
+    type: {{ .Values.strategy.type | default "Recreate" | quote }}
+    {{- else }}
+    type: {{ .Values.strategy.type | default "RollingUpdate" | quote }}
+    {{- end }}
+  selector:
+    matchLabels:
+      {{- include "wg-access-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml" ) . | sha256sum }}
+      labels:
+        {{- include "wg-access-server.selectorLabels" . | nindent 8 }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            capabilities:
+              add: ['NET_ADMIN']
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8000
+              protocol: TCP
+            - name: wireguard
+              containerPort: {{ .Values.wireguard.service.port }}
+              protocol: UDP
+          env:
+            - name: WG_WIREGUARD_PORT
+              value: {{ .Values.wireguard.service.port | quote }}
+            {{- if .Values.wireguard.config.privateKey }}
+            - name: WG_WIREGUARD_PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ $fullName }}"
+                  key: privateKey
+            {{- end }}
+            {{- if .Values.web.config.adminUsername }}
+            - name: WG_ADMIN_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ $fullName }}"
+                  key: adminUsername
+            {{- end}}
+            - name: WG_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ $fullName }}"
+                  key: adminPassword
+          volumeMounts:
+            - name: tun
+              mountPath: /dev/net/tun
+            - name: data
+              mountPath: /data
+            - name: config
+              mountPath: /config.yaml
+              subPath: config.yaml
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: tun
+          hostPath:
+            type: 'CharDevice'
+            path: /dev/net/tun
+        - name: data
+        {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ $fullName }}{{- end }}
+        {{- end }}
+        {{- if not .Values.persistence.enabled }}
+          emptyDir: {}
+        {{- end }}
+        - name: config
+          configMap:
+            name: "{{ $fullName }}"
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/wg-access-server/templates/ingress.yaml
+++ b/charts/wg-access-server/templates/ingress.yaml
@@ -1,0 +1,50 @@
+{{- $kubeTargetVersion := default .Capabilities.KubeVersion.GitVersion .Values.kubeTargetVersionOverride }}
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "wg-access-server.fullname" . -}}
+{{- if semverCompare ">=1.19-0" $kubeTargetVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" $kubeTargetVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "wg-access-server.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+{{- end }}
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: /
+            backend:
+            {{- if semverCompare ">=1.19-0" $kubeTargetVersion }}
+              service:
+                name: {{ $fullName }}-web
+                port:
+                  number: 80
+            pathType: Prefix
+            {{- else -}}
+              serviceName: {{ $fullName }}-web
+              servicePort: http
+            {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/wg-access-server/templates/pvc.yaml
+++ b/charts/wg-access-server/templates/pvc.yaml
@@ -1,0 +1,26 @@
+{{- if and ( .Values.persistence.enabled) ( not .Values.persistence.existingClaim ) -}}
+{{- $fullName := include "wg-access-server.fullname" . -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ $fullName }}"
+  labels:
+    {{- include "wg-access-server.labels" . | nindent 4 }}
+  {{- with .Values.persistence.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+{{ toYaml .Values.persistence.accessModes | indent 4 }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+{{- end }}
+{{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- end -}}

--- a/charts/wg-access-server/templates/secret.yaml
+++ b/charts/wg-access-server/templates/secret.yaml
@@ -1,0 +1,14 @@
+{{- $fullName := include "wg-access-server.fullname" . -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ $fullName }}"
+  labels:
+    {{- include "wg-access-server.labels" . | nindent 4 }}
+type: Opaque
+data:
+  privateKey: {{ .Values.wireguard.config.privateKey | b64enc | quote }}
+  {{- if .Values.web.config.adminUsername }}
+  adminUsername: {{ .Values.web.config.adminUsername | b64enc | quote }}
+  {{- end }}
+  adminPassword: {{ (include "wg-access-server.adminPassword" .) | b64enc | quote }}

--- a/charts/wg-access-server/templates/service.yaml
+++ b/charts/wg-access-server/templates/service.yaml
@@ -1,0 +1,59 @@
+{{- $fullName := include "wg-access-server.fullname" . -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-web
+  labels:
+    {{- include "wg-access-server.labels" . | nindent 4 }}
+{{- if .Values.web.service.annotations }}
+  annotations:
+{{ toYaml .Values.web.service.annotations | indent 4 }}
+{{- end }}
+spec:
+{{- if .Values.web.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.web.service.externalTrafficPolicy }}
+{{- end }}
+  type: {{  .Values.web.service.type }}
+{{- if and ( eq .Values.web.service.type "LoadBalancer" ) ( .Values.web.service.loadBalancerIP ) }}
+  loadBalancerIP: {{ .Values.web.service.loadBalancerIP }}
+{{- end }}
+  ports:
+    - port: 80
+      targetPort: 8000
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "wg-access-server.selectorLabels" . | nindent 4 }}
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullName }}-wireguard
+  labels:
+    {{- include "wg-access-server.labels" . | nindent 4 }}
+{{- if .Values.wireguard.service.annotations }}
+  annotations:
+{{ toYaml .Values.wireguard.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.wireguard.service.type }}
+  sessionAffinity: {{ .Values.wireguard.service.sessionAffinity }}
+{{- if .Values.wireguard.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.wireguard.service.externalTrafficPolicy }}
+{{- end }}
+  ipFamilyPolicy: {{ .Values.wireguard.service.ipFamilyPolicy }}
+{{- if and ( eq .Values.wireguard.service.type "LoadBalancer" ) ( .Values.wireguard.service.loadBalancerIP ) }}
+  loadBalancerIP: {{ .Values.wireguard.service.loadBalancerIP }}
+{{- end }}
+  ports:
+    - port: {{ .Values.wireguard.service.port }}
+      targetPort: {{ .Values.wireguard.service.port }}
+{{- if and ( eq .Values.wireguard.service.type "NodePort" ) ( .Values.wireguard.service.nodePort ) }}
+      nodePort: {{ .Values.wireguard.service.nodePort }}
+{{- end }}
+      protocol: UDP
+      name: wireguard
+  selector:
+    {{- include "wg-access-server.selectorLabels" . | nindent 4 }}

--- a/charts/wg-access-server/values.yaml
+++ b/charts/wg-access-server/values.yaml
@@ -1,0 +1,99 @@
+# wg-access-server config
+config:
+  # IPv6 is disabled by default, since it leads to the pod failing if the
+  # k8s-cluster is not configured with IPv6 support
+  vpn:
+    cidrv6: 0
+
+web:
+  config:
+    adminUsername: "admin"
+    adminPassword: ""
+  service:
+    annotations: {}
+    externalTrafficPolicy: ""
+    type: ClusterIP
+    loadBalancerIP: ""
+
+wireguard:
+  config:
+    privateKey: ""
+  service:
+    annotations: {}
+    type: ClusterIP
+    sessionAffinity: ClientIP
+    externalTrafficPolicy: ""
+    ipFamilyPolicy: SingleStack
+    loadBalancerIP: ""
+    port: 51820
+    nodePort: ""
+
+persistence:
+  enabled: false
+  existingClaim: ""
+  annotations: {}
+  accessModes:
+    - ReadWriteOnce
+
+  ## Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  storageClass: ""
+  size: 100Mi
+
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  ingressClassName: ""
+  hosts: []
+    # - www.example.com
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+nameOverride: ""
+
+fullnameOverride: ""
+
+imagePullSecrets: []
+
+image:
+  repository: ghcr.io/freifunkmuc/wg-access-server
+  tag: ""
+  pullPolicy: IfNotPresent
+
+# multiple replicas is only supported when using
+# a supported highly-available storage backend (i.e. postgresql)
+replicas: 1
+
+strategy:
+  type: ""
+  # the deployment strategy type will default to "Recreate" when persistence is enabled
+  # or "RollingUpdate" when persistence is not enabled.
+  # type: Recreate
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
This adds the chart source files in their current version from https://github.com/freifunkMUC/wg-access-server to this repository to get started. The folder structure is copied from https://github.com/authelia/chartrepo which has been mentioned as orientation example in https://github.com/freifunkMUC/wg-access-server/issues/97 . 
URLs haven't been updated because I don't know how they'll look like yet.

@elcomtik @zandemax @DerRockWolf does this help to get started?
Feel free to do with it whatever you want, this is just so you have a starting point which you can work with.