### PR TITLE
Allow setting hostNetwork and securityContext in values.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ ingress:
 | ingress.tls | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | fullnameOverride | string | `""` |  |
+| hostNetwork | bool | `false` | Run the application pod in the host network of the node |
 | imagePullSecrets | list | `[]` |  |
 | image.repository | string | `"ghcr.io/freifunkmuc/wg-access-server"` |  |
 | image.tag | string | `""` |  |
@@ -108,6 +109,7 @@ ingress:
 | replicas | int | `1` |  |
 | strategy.type | string | `""` | `Recreate` if `persistence.enabled` true or `RollingUpdate` if false |
 | resources | object | `{}` | pod cpu/memory resource requests and limits |
+| securityContext | object | `{"capabilities":{"add": ["NET_ADMIN"]}}` | Set `securityContext` for the application pod |
 | nodeSelector | object | `{}` |  |
 | tolerations | list | `[]` |  |
 | affinity | object | `{}` |  |

--- a/charts/wg-access-server/Chart.yaml
+++ b/charts/wg-access-server/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v0.8.4
 description: A Wireguard VPN Access Server
 name: wg-access-server
-version: 0.10.1
+version: 0.11.0

--- a/charts/wg-access-server/templates/deployment.yaml
+++ b/charts/wg-access-server/templates/deployment.yaml
@@ -24,6 +24,7 @@ spec:
       labels:
         {{- include "wg-access-server.selectorLabels" . | nindent 8 }}
     spec:
+      hostNetwork: {{ .Values.hostNetwork | default "false" }}
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -51,8 +52,12 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
+          {{- if .Values.securityContext  }}
+          {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- else }}
             capabilities:
               add: ['NET_ADMIN']
+          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/wg-access-server/values.yaml
+++ b/charts/wg-access-server/values.yaml
@@ -92,7 +92,7 @@ nameOverride: ""
 
 fullnameOverride: ""
 
-# use the host network for the main container. Set to "true" if you want the
+# use the host network for the application pod. Set to "true" if you want the
 # underlying K8S network to be reachable via the VPN.
 # hostNetwork: false
 
@@ -113,7 +113,7 @@ strategy:
   # or "RollingUpdate" when persistence is not enabled.
   # type: Recreate
 
-# set securityContext for the main container. With some kernel versions, adding the
+# set securityContext for the application pod. With some kernel versions, adding the
 # 'NET_RAW' capability might be required for the iptables table to be initialized.
 # securityContext:
 #   capabilities:

--- a/charts/wg-access-server/values.yaml
+++ b/charts/wg-access-server/values.yaml
@@ -92,6 +92,10 @@ nameOverride: ""
 
 fullnameOverride: ""
 
+# use the host network for the main container. Set to "true" if you want the
+# underlying K8S network to be reachable via the VPN.
+# hostNetwork: false
+
 imagePullSecrets: []
 
 image:
@@ -108,6 +112,12 @@ strategy:
   # the deployment strategy type will default to "Recreate" when persistence is enabled
   # or "RollingUpdate" when persistence is not enabled.
   # type: Recreate
+
+# set securityContext for the main container. With some kernel versions, adding the
+# 'NET_RAW' capability might be required for the iptables table to be initialized.
+# securityContext:
+#   capabilities:
+#     add: ['NET_ADMIN']
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This PR allows setting `hostNetwork` and `securityContext` for the main container via `values.yaml` while keeping the current values as the default.

The use cases for setting non-default values for these variables are described in the comments in `values.yaml`.

While `hostNetwork` is almost self-explanatory, I feel like `securityContext` needs some extra explanation, so I'll provide it below.

For some reason, the container fails to start on my servers unless the `NET_RAW` capability is added. The error message looks like this:
`time="2023-03-20T12:50:26Z" level=error msg="failed to read table filter: running [/sbin/iptables -t filter -S WG_ACCESS_SERVER_FORWARD 1 --wait]: exit status 3: iptables v1.8.8 (legacy): can't initialize iptables table 'filter': Permission denied (you must be root)\nPerhaps iptables or your kernel needs to be upgraded.\n" file="main.go:152"`

Most probably, the reason for that is a specific kernel or iptables version, which I'm too lazy to investigate. Even if I'm somehow wrong, having a couple of extra settings for the chart won't do any harm (granted that the defaults remain unchanged, of course :)).
```
[root@k8s-dmz-01-ng-vpn-02-0 ~]# cat /etc/*release | head -n 1
AlmaLinux release 9.0 (Emerald Puma)
[root@k8s-dmz-01-ng-vpn-02-0 ~]# uname -r
5.14.0-70.17.1.el9_0.x86_64
[root@k8s-dmz-01-ng-vpn-02-0 ~]# yum list installed | grep iptables
iptables-libs.x86_64                 1.8.7-28.el9                  @baseos
iptables-nft.x86_64                  1.8.7-28.el9                  @baseos
```
