### PR TITLE
Return proper chart.name/nameOverride if fullnameOverride not set

### DIFF
--- a/charts/wg-access-server/templates/_helpers.tpl
+++ b/charts/wg-access-server/templates/_helpers.tpl
@@ -15,7 +15,7 @@ If release name contains chart name it will be used as a full name.
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
-{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Hello, 

When `persistence.enabled=true` is set on the chart, the PVC is returned with an empty name:

```
helm template --set persistence.enabled=true . | grep -A2 PersistentVolumeClaim
kind: PersistentVolumeClaim
metadata:
  name: ""
```

this is due to the definition not returning a value, I have proposed a fix in the PR.

---

also, wondering if the rest of the templates that set `$fullName` be adjusted to use `wg-access-server.fullname`?

 ```
grep -Er '\$fullName.*include*'
templates/service.yaml:{{- $fullName := include "wg-access-server.name" . -}}
templates/pvc.yaml:{{- $fullName := include "wg-access-server.fullname" . -}}
templates/NOTES.txt:{{- $fullName := include "wg-access-server.name" . }}
templates/deployment.yaml:{{- $fullName := include "wg-access-server.name" . -}}
templates/ingress.yaml:{{- $fullName := include "wg-access-server.name" . -}}
templates/secret.yaml:{{- $fullName := include "wg-access-server.name" . -}}

```

Thank you