### PR TITLE
Fix #25 - Config not being loaded

### DIFF
--- a/charts/wg-access-server/templates/deployment.yaml
+++ b/charts/wg-access-server/templates/deployment.yaml
@@ -107,6 +107,15 @@ spec:
             - name: data
               mountPath: /data
             {{- end }}
+            {{- if or .Values.secretConfig.config .Values.secretConfig.existingSecret }}
+            - mountPath: /config.yaml
+              subPath: config.yaml
+              name: merged-config
+            {{- else }}
+            - mountPath: /config.yaml
+              subPath: config.yaml
+              name: configmap-config
+            {{- end }}
           {{- with .Values.extraVolumeMounts }}
             {{- tpl ( . | toYaml ) $ | nindent 12 }}
           {{- end}}


### PR DESCRIPTION
This should fix issue #25 where the config is no longer being loaded. It mounts either the original config, or the merged config if that is enabled.