### PR TITLE
Fix readiness port probe. Introduce liveness probe

### DIFF
--- a/charts/wg-access-server/templates/deployment.yaml
+++ b/charts/wg-access-server/templates/deployment.yaml
@@ -120,9 +120,9 @@ spec:
             {{- tpl ( . | toYaml ) $ | nindent 12 }}
           {{- end}}
           readinessProbe:
-            httpGet:
-              path: /
-              port: http
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:

--- a/charts/wg-access-server/values.yaml
+++ b/charts/wg-access-server/values.yaml
@@ -186,3 +186,25 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: 8000
+    scheme: HTTP
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 2
+  successThreshold: 1
+  failureThreshold: 3
+
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8000
+    scheme: HTTP
+  initialDelaySeconds: 10
+  periodSeconds: 20
+  timeoutSeconds: 2
+  successThreshold: 1
+  failureThreshold: 3


### PR DESCRIPTION
After I've configured oidc with keycloak my kubernetes started complaining about redirects.

<details>
<summary>Here is what I got.</summary>
<img width="707" height="556" alt="image" src="https://github.com/user-attachments/assets/41bf8797-13fc-40fd-bf99-d02284eec5b8" />
</details>

This caused me to investigate and I've found that readiness probe was checking path `/`, which is ambigous, according to [actual health check path](https://github.com/freifunkMUC/wg-access-server/blob/591d7cc05579ab87e79598f172a368b216d21451/cmd/serve/main.go#L248-249)

That's why I've moved the readiness probe to values.yaml with default values. And I've also introduced health probe, because it's good practice to have both.

### Tests I've performed

1. Tested helm rendering
```bash
helm template example-release .\charts\wg-access-server\ -f .\my-values.yaml
```
2. Tested kubectl apply (on k3s)
```bash
helm template example-release .\charts\wg-access-server\ -f .\my-values.yaml | kubectl apply --dry-run=client -f -
```

<details>
<summary>my-values.yaml</summary>

```yaml
replicas: 1

nameOverride: wg-name

# === VPN configuration ===
config:
  vpn:
    allowedIPs:
      - "0.0.0.0/0"
      - "::/0"
    addressPool:
      ipv4: "10.13.13.0/24"
      
  auth:
    oidc:
      # A name for the backend (is shown on the login page and possibly in the devices list of the 'all devices' admin page)
      name: "My Keycloak"
      # Should point to the OIDC Issuer (excluding /.well-known/openid-configuration)
      issuer: "https://redacted.domain/realms/redacted"
      # Your OIDC client credentials which would be provided by your OIDC provider
      clientID: "redacted"
      clientSecret: "redacted"
      # The full redirect URL
      # The path can be almost anything as long as it doesn't
      # conflict with a path that the web UI uses.
      # /callback is recommended.
      redirectURL: "https://redacted.domain/callback"
      # List of scopes to request claims for. Must include 'openid'.
      # Must include 'email' if 'emailDomains' is used. Can include 'profile' to show the user's name in the UI.
      # Add custom ones if required for 'claimMapping'.
      # Defaults to ["openid"]
      scopes:
        - openid
        - profile
        - email
      # You can optionally restrict access to users with an email address
      # that matches an allowed domain.
      # If empty or omitted then all email domains will be allowed.
      emailDomains:
        - redacted.domain
      # This is an advanced feature that allows you to define OIDC claim mapping expressions.
      # This feature is used to define wg-access-server admins based off a claim in your OIDC token.
      # A JSON-like object of claimKey: claimValue pairs as returned by the issuer is passed to the evaluation function.
      # See https://github.com/Knetic/govaluate/blob/9aa49832a739dcd78a5542ff189fb82c3e423116/MANUAL.md for the syntax.
      claimMapping:
        # This example works if you have a custom group_membership claim which is a list of strings
        admin: "'admin' in wireguard_access_server_ext_roles"
        access: "'access' in wireguard_access_server_ext_roles"
      # Let wg-access-server retrieve the claims from the ID Token instead of querying the UserInfo endpoint.
      # Some OIDC authorization provider implementations (e.g. ADFS) only publish claims in the ID Token.
      claimsFromIDToken: false
      # require this claim to be "true" to allow access for the user
      accessClaim: "access"

web:
  config:
    basicAuthEnabled: false

# === WireGuard setup ===
wireguard:
  config:
    privateKey: "redacted"
    useHostNetwork: false
    port: 12345
  service:
    type: LoadBalancer
    port: 12345
    annotations:
      redacted: true
    loadBalancerIP: 1.2.3.4

# === Node placement (worker node only) ===
nodeSelector:
  redacted: "true"
  
storage:
  enabled: true
  uri: "postgresql://redacted:redacted@postgres.data.svc.cluster.local:5432/redacted?sslmode=disable"

# === Persistence ===
persistence:
  enabled: true
  size: "200Mi"
  accessModes:
    - ReadWriteOnce

# === Web UI ingress ===
ingress:
  enabled: true
  annotations:
    redacted: true
  ingressClassName: traefik
  hosts:
    - redacted.domain
  tls:
    - hosts:
        - redacted.domain
      secretName: redacted-domain-tls
```
</details>

And the result was

<img width="275" height="75" alt="image" src="https://github.com/user-attachments/assets/eea9bfa2-3c76-4998-b0a8-6f53cb16891e" />
