### PR TITLE
Add podLabels and podAnnotations values

### DIFF
--- a/charts/wg-access-server/Chart.yaml
+++ b/charts/wg-access-server/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: v1.0.0
 description: A WireGuard VPN Access Server
 name: wg-access-server
-version: 1.0.0
+version: 1.1.0

--- a/charts/wg-access-server/README.md
+++ b/charts/wg-access-server/README.md
@@ -125,6 +125,8 @@ ingress:
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | replicas | int | `1` |  |
 | strategy.type | string | `""` | `Recreate` if `persistence.enabled` true or `RollingUpdate` if false |
+| podLabels | object | `{}` | Extra labels merged into the pod template, alongside the chart's own selector labels. |
+| podAnnotations | object | `{}` | Extra annotations merged into the pod template, alongside the chart's own checksum annotations. |
 | resources | object | `{}` | pod cpu/memory resource requests and limits |
 | nodeSelector | object | `{}` |  |
 | tolerations | list | `[]` |  |

--- a/charts/wg-access-server/templates/deployment.yaml
+++ b/charts/wg-access-server/templates/deployment.yaml
@@ -21,8 +21,14 @@ spec:
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml" ) . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
         {{- include "wg-access-server.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       hostNetwork: {{ .Values.hostNetwork | default "false" }}
     {{- with .Values.imagePullSecrets }}

--- a/charts/wg-access-server/values.yaml
+++ b/charts/wg-access-server/values.yaml
@@ -172,6 +172,17 @@ strategy:
   # or "RollingUpdate" when persistence is not enabled.
   # type: Recreate
 
+# Extra labels to add to the pod template, merged alongside the chart's own
+# selector labels. Useful for e.g. giving a common label across multiple
+# releases of this chart so a single ServiceMonitor/PodMonitor-style
+# resource can select all of them without listing each release by name.
+podLabels: {}
+
+# Extra annotations to add to the pod template, merged alongside the
+# chart's own checksum annotations. Useful for e.g. Prometheus
+# scrape-annotation-based service discovery (prometheus.io/scrape, etc).
+podAnnotations: {}
+
 # set securityContext for the application pod. With some kernel versions, adding the
 # 'NET_RAW' capability might be required for the iptables table to be initialized.
 securityContext:


### PR DESCRIPTION
### What

Adds two new values, `podLabels` and `podAnnotations`, merged into the Deployment's pod template alongside the chart's existing selector labels and checksum annotations. Both default to `{}` — no behavior change unless set.

I'm not sure if chart version bump is desired, if not - tell me, so I revert it.

### Why
When running multiple releases of this chart (e.g. one per VPN instance/environment), there's currently no way to give them a common label without templating changes on the consumer side. `app.kubernetes.io/name` resolves to `nameOverride`, which is typically unique per release, so nothing distinguishes "these are all wg-access-server" for downstream tooling.

`podLabels` lets a consumer add e.g. `app.kubernetes.io/part-of: wg-access-server` so a single monitoring resource (ServiceMonitor/PodMonitor-style) can select across every release instead of listing each one by name. `podAnnotations` covers the equivalent case for annotation-based scrape discovery (`prometheus.io/scrape`, etc.).

I encountered this when I decided to write a PodScrape targetting my vpns and found no way to distinguish them clearly.

### Testing
`helm lint` passes
`helm template` verified in both the default (unset) and populated case — confirmed no output changes when unset, and correct label/annotation merge when set.

Verified on my own installation with the following
```yaml
podLabels:
  test.birdegop.ru/wg: "true"
```
```bash
kubectl -n redacted get deploy redacted -o jsonpath='{.spec.template.metadata.labels}'
```
```json
{ "other-labels": "omitted", "test.birdegop.ru/wg":"true"}
```

Disclosure: this change was written with AI, reviewed and validated against real installation.